### PR TITLE
use floordiv instead of truediv to get _groupSpace

### DIFF
--- a/wx/lib/masked/numctrl.py
+++ b/wx/lib/masked/numctrl.py
@@ -583,7 +583,7 @@ class NumCtrl(BaseMaskedTextCtrl, NumCtrlAccessorsMixin):
 
         self._integerWidth = init_args['integerWidth']
         if init_args['groupDigits']:
-            self._groupSpace = (self._integerWidth - 1) / 3
+            self._groupSpace = (self._integerWidth - 1) // 3
         else:
             self._groupSpace = 0
         intmask = '#{%d}' % (self._integerWidth + self._groupSpace)
@@ -697,7 +697,7 @@ class NumCtrl(BaseMaskedTextCtrl, NumCtrlAccessorsMixin):
                 self._groupDigits = kwargs['groupDigits']
 
             if self._groupDigits:
-                self._groupSpace = (self._integerWidth - 1) / 3
+                self._groupSpace = (self._integerWidth - 1) // 3
             else:
                 self._groupSpace = 0
 


### PR DESCRIPTION
Actual code use truediv ('/') to calculate _groupSpace, but in python 3.x this leads to a float result, instead of an integer as one would expect.
Using floordiv ('//') instead, resolve the problem.

